### PR TITLE
Feature: define and alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,19 @@ Start your dev environment by running... `npm run dev`
     --external       Specify external dependencies  (default none)
     --globals        Specify global dependencies  (default none)
     --jsx            A custom JSX pragma like React.createElement  (default h)
+    --define         Inline constants  (default none)
+    --alias          Remap imports from one module to another  (default none)
     --open           Automatically open browser  (default true)
     --port           Specify a port  (default 3000)
     --single         Serve single page app  (default false)
     --ws             Specify a port for the reload ws  (default 3301)
     -h, --help       Displays this message
+```
+
+The syntax for `--define` and `--alias` are as follows:
+
+```bash
+$ microenvi --define process.env.NODE_ENV=production,NUM=123,BOOL=true
+# and
+$ microenvi --alias react=preact-compat,react-dom=preact-compat
 ```

--- a/cli.js
+++ b/cli.js
@@ -14,6 +14,7 @@ prog
 	.option('--globals', 'Specify global dependencies', 'none')
 	.option('--jsx', 'A custom JSX pragma like React.createElement', 'h')
 	.option('--define', 'Inline constants', 'none')
+	.option('--alias', 'Remap imports from one module to another', 'none')
 	.option('--open', 'Automatically open browser', true)
 	.option('--port', 'Specify a port', 3000)
 	.option('--single', 'Serve single page app', false)

--- a/cli.js
+++ b/cli.js
@@ -13,6 +13,7 @@ prog
 	.option('--external', 'Specify external dependencies', 'none')
 	.option('--globals', 'Specify global dependencies', 'none')
 	.option('--jsx', 'A custom JSX pragma like React.createElement', 'h')
+	.option('--define', 'Inline constants', 'none')
 	.option('--open', 'Automatically open browser', true)
 	.option('--port', 'Specify a port', 3000)
 	.option('--single', 'Serve single page app', false)

--- a/index.js
+++ b/index.js
@@ -130,6 +130,7 @@ module.exports = function(options) {
 		globals: options.globals,
 		jsx: options.jsx,
 		define: options.define,
+		alias: options.alias,
 		onBuild() {
 			if (firstBuild && options.open) {
 				firstBuild = false;

--- a/index.js
+++ b/index.js
@@ -129,6 +129,7 @@ module.exports = function(options) {
 		format: 'es',
 		globals: options.globals,
 		jsx: options.jsx,
+		define: options.define,
 		onBuild() {
 			if (firstBuild && options.open) {
 				firstBuild = false;


### PR DESCRIPTION
### Features:
* `--define`
  * Allows the developer to inline the values of constants, very useful for environment variables.
  * Current description: "Inline constants"
  * Default value: none
* `--alias`
  * Allows the developer to remap imports from one module to another for things like mapping `react` to `preact-compat`.
  * Current description: "Remap imports from one module to another"
  * Default value: none

I've updated the README to reflect the change to the usage, as well as, added a small example of how to use the two new options.

Both of these features are just mapping the cli to the call to `microbundle` so the syntaxes used can be found here: [microbundle release version 0.10.1](https://github.com/developit/microbundle/releases/tag/0.10.1)
Closes #2 